### PR TITLE
Add instructions on .env file setup in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # Northcoders News API
+
+## Environment Setup
+
+This repository does not contain the necessary .env files that set the value of PGDATABASE to a specific database, as they are part of the gitignore and will only be stored locally. You will need to create two .env files:
+
+_.env.development_
+
+```
+PGDATABASE=nc_news
+```
+
+_.env.test_
+
+```
+PGDATABASE=nc_news_test
+```


### PR DESCRIPTION
Added instructions to the readme for those wishing to clone the repo, on how to set up .env files.