### PR TITLE
Add PATCH /api/articles/:artcle_id model and controller, as well as 400 error handling

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -79,7 +79,7 @@ describe('app', () => {
         .patch('/api/articles/1')
         .send(voteUpdate)
         .expect(200)
-        .then(({ body: article }) => {
+        .then(({ body: { article } }) => {
           expect.objectContaining({
             article: {
               author: expect.any(String),
@@ -91,7 +91,7 @@ describe('app', () => {
               votes: expect.any(Number),
             },
           });
-          expect(article.article.votes).toBe(110);
+          expect(article.votes).toBe(110);
         });
     });
     test('Status: 200 - should respond with updated article if number passed is negative', () => {
@@ -100,7 +100,7 @@ describe('app', () => {
         .patch('/api/articles/1')
         .send(voteUpdate)
         .expect(200)
-        .then(({ body: article }) => {
+        .then(({ body: { article } }) => {
           expect.objectContaining({
             article: {
               author: expect.any(String),
@@ -112,7 +112,7 @@ describe('app', () => {
               votes: expect.any(Number),
             },
           });
-          expect(article.article.votes).toBe(90);
+          expect(article.votes).toBe(90);
         });
     });
     test('Status: 400 - responds with error message "bad request", when value is not a number', () => {
@@ -133,6 +133,16 @@ describe('app', () => {
         .expect(400)
         .then(({ body: { msg } }) => {
           expect(msg).toBe('bad request');
+        });
+    });
+    test('Status: 404 - should respond with error message for a valid but non-existent: article not found', () => {
+      const voteUpdate = { inc_votes: 10 };
+      return request(app)
+        .patch('/api/articles/972390472')
+        .send(voteUpdate)
+        .expect(404)
+        .then(({ body: { msg } }) => {
+          expect(msg).toBe('article not found');
         });
     });
   });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -125,7 +125,7 @@ describe('app', () => {
           expect(msg).toBe('bad request');
         });
     });
-    test('Status: 400 - should respond with error message "article not found" when id is invalid', () => {
+    test('Status: 400 - should respond with error message "bad request", when id is invalid', () => {
       const voteUpdate = { inc_votes: 10 };
       return request(app)
         .patch('/api/articles/not-an-id')

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -71,4 +71,69 @@ describe('app', () => {
         });
     });
   });
+  describe('PATCH -  /api/articles/:article_id', () => {
+    //404 and 500 already covered
+    test('Status: 200 - should respond with updated article', () => {
+      const voteUpdate = { inc_votes: 10 };
+      return request(app)
+        .patch('/api/articles/1')
+        .send(voteUpdate)
+        .expect(200)
+        .then(({ body: article }) => {
+          expect.objectContaining({
+            article: {
+              author: expect.any(String),
+              title: expect.any(String),
+              article_id: expect.any(Number),
+              body: expect.any(String),
+              topic: expect.any(String),
+              created_at: expect.any(Number),
+              votes: expect.any(Number),
+            },
+          });
+          expect(article.article.votes).toBe(110);
+        });
+    });
+    test('Status: 200 - should respond with updated article if number passed is negative', () => {
+      const voteUpdate = { inc_votes: -10 };
+      return request(app)
+        .patch('/api/articles/1')
+        .send(voteUpdate)
+        .expect(200)
+        .then(({ body: article }) => {
+          expect.objectContaining({
+            article: {
+              author: expect.any(String),
+              title: expect.any(String),
+              article_id: expect.any(Number),
+              body: expect.any(String),
+              topic: expect.any(String),
+              created_at: expect.any(Number),
+              votes: expect.any(Number),
+            },
+          });
+          expect(article.article.votes).toBe(90);
+        });
+    });
+    test('Status: 400 - responds with error message "bad request", when value is not a number', () => {
+      const invalidUpdate = { inc_votes: 'not-a-number' };
+      return request(app)
+        .patch('/api/articles/1')
+        .send(invalidUpdate)
+        .expect(400)
+        .then(({ body: { msg } }) => {
+          expect(msg).toBe('bad request');
+        });
+    });
+    test('Status: 400 - should respond with error message "article not found" when id is invalid', () => {
+      const voteUpdate = { inc_votes: 10 };
+      return request(app)
+        .patch('/api/articles/not-an-id')
+        .send(voteUpdate)
+        .expect(400)
+        .then(({ body: { msg } }) => {
+          expect(msg).toBe('bad request');
+        });
+    });
+  });
 });

--- a/app.js
+++ b/app.js
@@ -1,6 +1,9 @@
 const express = require('express');
 const { getTopics } = require('./controllers/topics.controller');
-const { getArticleById } = require('./controllers/articles.controller');
+const {
+  getArticleById,
+  patchVotesByID,
+} = require('./controllers/articles.controller');
 const {
   handle404,
   handle500,
@@ -9,9 +12,11 @@ const {
 } = require('./controllers/errors.controller');
 
 const app = express();
+app.use(express.json());
 
 app.get('/api/topics', getTopics);
 app.get('/api/articles/:article_id', getArticleById);
+app.patch('/api/articles/:article_id', patchVotesByID);
 
 app.all('/*', handle404); //Using app.all to apply this controller function to all bad paths
 app.use(handleCustomErrors);

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -1,8 +1,21 @@
-const { fetchArticleById } = require('../models/articles.model');
+const {
+  fetchArticleById,
+  updateVotesById,
+} = require('../models/articles.model');
 
 exports.getArticleById = (req, res, next) => {
   const { article_id: id } = req.params;
   fetchArticleById(id)
+    .then((article) => {
+      res.status(200).send({ article: article });
+    })
+    .catch(next);
+};
+
+exports.patchVotesByID = (req, res, next) => {
+  const { article_id } = req.params;
+  const { inc_votes } = req.body;
+  updateVotesById(article_id, inc_votes)
     .then((article) => {
       res.status(200).send({ article: article });
     })

--- a/controllers/errors.controller.js
+++ b/controllers/errors.controller.js
@@ -5,8 +5,9 @@ exports.handle404 = (req, res) => {
 exports.handleCustomErrors = (err, req, res, next) => {
   if (err.status) {
     res.status(err.status).send({ msg: err.msg });
+  } else {
+    next(err);
   }
-  next(err);
 };
 
 exports.handlePsqlErrors = (err, req, res, next) => {

--- a/controllers/errors.controller.js
+++ b/controllers/errors.controller.js
@@ -12,7 +12,7 @@ exports.handleCustomErrors = (err, req, res, next) => {
 
 exports.handlePsqlErrors = (err, req, res, next) => {
   if (err.code === '22P02') res.status(400).send({ msg: 'bad request' });
-  next(err);
+  else next(err);
 };
 
 exports.handle500 = exports.handle500 = (err, req, res, next) => {

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -10,3 +10,17 @@ exports.fetchArticleById = (id) => {
       return article[0];
     });
 };
+
+exports.updateVotesById = (id, votes) => {
+  return db
+    .query(
+      'UPDATE articles SET votes = votes + $2 WHERE article_id = $1 RETURNING *;',
+      [id, votes]
+    )
+    .then(({ rows: article }) => {
+      if (article.length === 0) {
+        return Promise.reject({ status: 404, msg: 'article not found' });
+      }
+      return article[0];
+    });
+};


### PR DESCRIPTION
Adds:
- GET /api/articles/:artcle_id model and controller
-  Tests 200 status - both positive and negative integers
- Tests 400 status - invalid id, valid id but invalid body of inc_vote object

Already existing:
- 404 (path not found) and 500 (server error) already handled from previous ticket implementation