### PR TITLE
Add refactored articles.models.js and resolved fatal error in testing

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -64,12 +64,12 @@ describe('app', () => {
             expect.objectContaining({
               author: expect.any(String),
               title: expect.any(String),
-              article_id: expect.any(Number),
+              article_id: 1,
               body: expect.any(String),
               topic: expect.any(String),
               created_at: expect.any(String),
               votes: expect.any(Number),
-              comment_count: expect.any(String),
+              comment_count: '11',
             })
           );
         });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -40,18 +40,38 @@ describe('app', () => {
       return request(app)
         .get('/api/articles/1')
         .expect(200)
-        .then(({ body: article }) => {
-          expect.objectContaining({
-            article: {
+        .then(({ body: { article } }) => {
+          expect(article).toEqual(
+            expect.objectContaining({
               author: expect.any(String),
               title: expect.any(String),
               article_id: expect.any(Number),
               body: expect.any(String),
               topic: expect.any(String),
-              created_at: expect.any(Number),
+              created_at: expect.any(String),
               votes: expect.any(Number),
-            },
-          });
+            })
+          );
+        });
+    });
+    test('Status 200 - should respond with specified article object with comment_count property', () => {
+      return request(app)
+        .get('/api/articles/1')
+        .expect(200)
+        .then(({ body: { article } }) => {
+          console.log(article);
+          expect(article).toEqual(
+            expect.objectContaining({
+              author: expect.any(String),
+              title: expect.any(String),
+              article_id: expect.any(Number),
+              body: expect.any(String),
+              topic: expect.any(String),
+              created_at: expect.any(String),
+              votes: expect.any(Number),
+              comment_count: expect.any(String),
+            })
+          );
         });
     });
     test('Status: 400 - should respond with error message: bad request', () => {
@@ -80,17 +100,17 @@ describe('app', () => {
         .send(voteUpdate)
         .expect(200)
         .then(({ body: { article } }) => {
-          expect.objectContaining({
-            article: {
+          expect(article).toEqual(
+            expect.objectContaining({
               author: expect.any(String),
               title: expect.any(String),
               article_id: expect.any(Number),
               body: expect.any(String),
               topic: expect.any(String),
-              created_at: expect.any(Number),
+              created_at: expect.any(String),
               votes: expect.any(Number),
-            },
-          });
+            })
+          );
           expect(article.votes).toBe(110);
         });
     });
@@ -101,17 +121,17 @@ describe('app', () => {
         .send(voteUpdate)
         .expect(200)
         .then(({ body: { article } }) => {
-          expect.objectContaining({
-            article: {
+          expect(article).toEqual(
+            expect.objectContaining({
               author: expect.any(String),
               title: expect.any(String),
               article_id: expect.any(Number),
               body: expect.any(String),
               topic: expect.any(String),
-              created_at: expect.any(Number),
+              created_at: expect.any(String),
               votes: expect.any(Number),
-            },
-          });
+            })
+          );
           expect(article.votes).toBe(90);
         });
     });

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -2,7 +2,10 @@ const db = require('../db/connection');
 
 exports.fetchArticleById = (id) => {
   return db
-    .query('SELECT * FROM articles WHERE article_id = $1;', [id])
+    .query(
+      'SELECT articles.*, COUNT(comments) AS comment_count FROM comments LEFT JOIN articles ON articles.article_id = comments.article_id WHERE articles.article_id = $1 GROUP BY articles.article_id;',
+      [id]
+    )
     .then(({ rows: article }) => {
       if (article.length === 0) {
         return Promise.reject({ status: 404, msg: 'article not found' });


### PR DESCRIPTION
Apologies for changes to tests here but since the second ticket, the expect.objectContaining was implemented in a way that jest wasn't comparing to anything, and giving the impression of passing because it was still passing the toHaveLength test (I only noticed this when writing a new test with the "comment_count" property and having it pass anyway). 

Aside from that, I've added a refactored SQL query to add a comment_count.