### PR TITLE
Add refactor of GET /api/articles to include comment_count

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -212,6 +212,27 @@ describe('app', () => {
           expect(articles).toBeSortedBy('created_at', { descending: true });
         });
     });
+    test('Status: 200 - should respond with an array of article objects with comment count property ', () => {
+      return request(app)
+        .get('/api/articles')
+        .expect(200)
+        .then(({ body: articles }) => {
+          expect(articles).toHaveLength(12);
+          articles.forEach((article) => {
+            expect(article).toEqual(
+              expect.objectContaining({
+                author: expect.any(String),
+                title: expect.any(String),
+                article_id: expect.any(Number),
+                topic: expect.any(String),
+                created_at: expect.any(String), //Had to change to string given SQL formatting from number to string
+                votes: expect.any(Number),
+                comment_count: expect.any(String),
+              })
+            );
+          });
+        });
+    });
     //404 (invalid path -  handled and previously tested); 500 (server error - handled)
   });
 });

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -30,8 +30,12 @@ exports.updateVotesById = (id, votes) => {
 
 exports.fetchArticles = () => {
   return db
-    .query('SELECT * FROM articles ORDER BY created_at DESC;')
+    .query(
+      // right join needed to include articles that have no comments with count of 0
+      'SELECT articles.*, COUNT(comments) AS comment_count FROM comments RIGHT JOIN articles ON articles.article_id = comments.article_id GROUP BY articles.article_id ORDER BY created_at DESC;'
+    )
     .then(({ rows: articles }) => {
+      console.log(articles);
       return articles;
     });
 };


### PR DESCRIPTION
Adds:
- Refactor of fetchArticles in articles.model.js to include comment count
- Add passing status 200 test: checks length of array returned and presence of properties expected including comment_count