### PR TITLE
Add DELETE /api/comments/:comment_id model and controller with passing tests for 204, 400 and 404 statuses

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -419,12 +419,22 @@ describe('app', () => {
     });
   });
   describe('DELETE - /api/comments/:comment_id', () => {
-    test('Status: 204 - should delete comment by given id and return deleted comment object', () => {
+    test('Status: 204 - should delete comment by given id and return no content', () => {
       return request(app)
         .delete('/api/comments/1')
         .expect(204)
         .then(({ body }) => {
           expect(body).toEqual({});
+        });
+    });
+    test('Status: 204 - comment table contains one fewer comment', () => {
+      return request(app)
+        .delete('/api/comments/1')
+        .expect(204)
+        .then(() => {
+          return db.query('SELECT * FROM comments').then(({ rows }) => {
+            expect(rows).toHaveLength(17);
+          });
         });
     });
     test('Status: 400 - should return "bad request" when passed an invalid id ', () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -420,12 +420,7 @@ describe('app', () => {
   });
   describe('DELETE - /api/comments/:comment_id', () => {
     test('Status: 204 - should delete comment by given id and return no content', () => {
-      return request(app)
-        .delete('/api/comments/1')
-        .expect(204)
-        .then(({ body }) => {
-          expect(body).toEqual({});
-        });
+      return request(app).delete('/api/comments/1').expect(204);
     });
     test('Status: 204 - comment table contains one fewer comment', () => {
       return request(app)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -418,4 +418,30 @@ describe('app', () => {
         });
     });
   });
+  describe('DELETE - /api/comments/:comment_id', () => {
+    test('Status: 204 - should delete comment by given id and return deleted comment object', () => {
+      return request(app)
+        .delete('/api/comments/1')
+        .expect(204)
+        .then(({ body }) => {
+          expect(body).toEqual({});
+        });
+    });
+    test('Status: 400 - should return "bad request" when passed an invalid id ', () => {
+      return request(app)
+        .delete('/api/comments/not-an-id')
+        .expect(400)
+        .then(({ body: { msg } }) => {
+          expect(msg).toEqual('bad request');
+        });
+    });
+    test('Status: 404 - should return "comment does not exist" when passed a valid but non-existent comment id', () => {
+      return request(app)
+        .delete('/api/comments/2363457')
+        .expect(404)
+        .then(({ body: { msg } }) => {
+          expect(msg).toEqual('comment does not exist');
+        });
+    });
+  });
 });

--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const {
 const {
   getCommentsByArticleId,
   postCommentsByArticleId,
+  deleteCommentById,
 } = require('./controllers/comments.controller');
 const {
   handle404,
@@ -30,6 +31,8 @@ app.get('/api/articles/:article_id/comments', getCommentsByArticleId);
 app.post('/api/articles/:article_id/comments', postCommentsByArticleId);
 
 app.get('/api/users', getUsers);
+
+app.delete('/api/comments/:comment_id', deleteCommentById);
 
 app.all('/*', handle404); //Using app.all to apply this controller function to all bad paths
 app.use(handleCustomErrors);

--- a/controllers/api.controller.js
+++ b/controllers/api.controller.js
@@ -1,0 +1,9 @@
+const { fetchEndpointDescriptions } = require('../models/api.model.js');
+
+exports.getEndpoints = (req, res, next) => {
+  fetchEndpointDescriptions()
+    .then((descriptions) => {
+      res.status(200).send({ descriptions });
+    })
+    .catch(next);
+};

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -1,6 +1,7 @@
 const {
   fetchCommentsByArticleId,
   addCommentsbyArticleId,
+  removeCommentById,
 } = require('../models/comments.model');
 const { checkArticleExists } = require('../models/articles.model');
 
@@ -22,6 +23,17 @@ exports.postCommentsByArticleId = (req, res, next) => {
   addCommentsbyArticleId(id, body)
     .then((body) => {
       res.status(201).send({ comment: body[0] });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+exports.deleteCommentById = (req, res, next) => {
+  const { comment_id: id } = req.params;
+  removeCommentById(id)
+    .then(() => {
+      res.status(204).send();
     })
     .catch((err) => {
       next(err);

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -33,7 +33,7 @@ exports.deleteCommentById = (req, res, next) => {
   const { comment_id: id } = req.params;
   removeCommentById(id)
     .then(() => {
-      res.status(204).send();
+      res.sendStatus(204);
     })
     .catch((err) => {
       next(err);

--- a/models/api.model.js
+++ b/models/api.model.js
@@ -1,0 +1,8 @@
+const fs = require('fs/promises');
+
+exports.fetchEndpointDescriptions = async () => {
+  const descriptions = await fs.readFile('./endpoints.json', 'utf-8');
+  const parsedDescriptions = JSON.parse(descriptions);
+
+  return parsedDescriptions;
+};

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -1,3 +1,4 @@
+const { rows } = require('pg/lib/defaults');
 const db = require('../db/connection');
 
 exports.fetchCommentsByArticleId = (id) => {
@@ -35,4 +36,14 @@ exports.addCommentsbyArticleId = (id, reqBody) => {
         return comment;
       });
   }
+};
+
+exports.removeCommentById = (id) => {
+  return db
+    .query('DELETE FROM comments WHERE comment_id = $1 RETURNING *;', [id])
+    .then(({ rows }) => {
+      if (rows.length === 0) {
+        return Promise.reject({ status: 404, msg: 'comment does not exist' });
+      }
+    });
 };


### PR DESCRIPTION
Adds:
- DELETE /api/comments/:comment_id model and controller 
- Error handling for 400 (invalid id) and 404 (comment not found)
- Tests for 204, 400 and 404 statuses